### PR TITLE
Initialize admin user at startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+# local database and config files
+config.json
 *.db
-.obsidian
+# profile pictures
 webapp/static/profile_pics/*.jpg
 webapp/static/profile_pics/*.png
+# editor files: 
+*.swp
+.obsidian
+# local python files
 **/__pycache__/
 venv/
-config.json
+# macos specific
+.DS_Store

--- a/config.json-dist
+++ b/config.json-dist
@@ -6,6 +6,9 @@
 	"MAIL_USE_TLS": True,
 	"MAIL_USER": "MAIL_USER",
 	"MAIL_PASS": "MAIL_PASS",
-	"MAIL_REPLYTO": "MAIL_USER"
+	"MAIL_REPLYTO": "MAIL_USER",
+	"ADMIN_USER": "admin",
+	"ADMIN_EMAIL": "admin@example.org",
+	"ADMIN_PASSWORD": "changeme"
 }
 

--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -32,4 +32,30 @@ def create_app(config_class=Config):
     app.register_blueprint(main)
     app.register_blueprint(errors)
 
+    # setup admin user, if user name and password are set
+    # always reset password to configured password
+    upper = sum(c.isupper() for c in config_class.ADMIN_PASSWORD)
+    lower = sum(c.islower() for c in config_class.ADMIN_PASSWORD)
+    digit = sum(c.isdigit() for c in config_class.ADMIN_PASSWORD)
+    if len(config_class.ADMIN_USER) > 3 and len(config_class.ADMIN_PASSWORD) > 10 and upper>0 and lower>0 and digit>0:
+        from webapp.models import User
+        ctx=app.app_context()
+        ctx.push()
+        admin=User.query.filter_by(username=config_class.ADMIN_USER).first()
+        hashed_password = bcrypt.generate_password_hash(config_class.ADMIN_PASSWORD).decode('utf-8')
+        if admin:
+            print(f"INFO: User {config_class.ADMIN_USER} already exists - reset password and email")
+            admin.password = hashed_password
+            admin.email = config_class.ADMIN_EMAIL
+            db.session.commit()
+        else:
+            print(f"INFO: Create new admin user {config_class.ADMIN_USER}")
+            admin = User(username=config_class.ADMIN_USER, email=config_class.ADMIN_EMAIL, password=hashed_password)
+            db.session.add(admin)
+            db.session.commit()
+        ctx.pop()
+    else:
+        print("WARNING: password is not complex enough, not setting up admin user")
+
+
     return app

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -13,3 +13,6 @@ class Config:
     MAIL_USERNAME = config.get('MAIL_USER')
     MAIL_PASSWORD = config.get('MAIL_PASS')
     MAIL_REPLYTO = config.get('MAIL_REPLYTO')
+    ADMIN_USER = config.get('ADMIN_USER')
+    ADMIN_EMAIL = config.get('ADMIN_EMAIL')
+    ADMIN_PASSWORD = config.get('ADMIN_PASSWORD')


### PR DESCRIPTION
Beim Starten des Webservers, soll ein Admin User angelegt werden, falls dieser noch nicht existiert. Der Admin User dient dazu die Rollen zu verteilen (Rollen gibt es noch nicht, aber wir benötigen mindestens "Admin", "PowerUser", "Approver").
