### PR TITLE
Run only one thread in production

### DIFF
--- a/docker-startup.sh
+++ b/docker-startup.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 flask db upgrade
-exec gunicorn prod:app -b 0.0.0.0:5000 -w 4
+exec gunicorn prod:app -b 0.0.0.0:5000 -w 1
 


### PR DESCRIPTION
Currently, it seems, user logins are not thread-safe. Switching to single thread to workaround this.