### PR TITLE
Möglichkeit des Wiederrufs der Betreuung hinzugefügt

### DIFF
--- a/webapp/main/routes.py
+++ b/webapp/main/routes.py
@@ -6,10 +6,11 @@ from flask_login import current_user
 from webapp.main import main
 from webapp.model.db import db, Post, SystemParameters, ObservationRequest, PoweruserMeldung, User, Group
 from webapp.orders.constants import USER_ROLE_ADMIN, USER_ROLE_APPROVER, USER_ROLE_USER, USER_ROLE_GUEST,ORDER_STATUS_LABELS, ORDER_STATUS_WAITING, \
-    ORDER_STATUS_PU_REJECTED, ORDER_STATUS_PU_ACCEPTED, ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED
+    ORDER_STATUS_PU_REJECTED, ORDER_STATUS_PU_ACCEPTED, ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED, ORDER_STATUS_PU_ACTION_REQUIRED
 from webapp.orders.constants import ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED
 from sqlalchemy.exc import IntegrityError
 from collections import defaultdict
+from sqlalchemy import case
 
 @main.route("/")
 @main.route("/home")
@@ -110,7 +111,14 @@ def approver():
 
     all_orders = (
         ObservationRequest.query
-        .filter(ObservationRequest.status.in_([ORDER_STATUS_WAITING, ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED, ORDER_STATUS_PU_REJECTED, ORDER_STATUS_PU_ACCEPTED]))
+        .filter(ObservationRequest.status.in_([ORDER_STATUS_WAITING, ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED, ORDER_STATUS_PU_REJECTED, ORDER_STATUS_PU_ACCEPTED, ORDER_STATUS_PU_ACTION_REQUIRED]))
+        .order_by(
+        case(
+            (ObservationRequest.status == ORDER_STATUS_PU_ACTION_REQUIRED, 0),
+            else_=1
+        ),
+        ObservationRequest.id.desc()
+    )
         .all()
     )
     for order in all_orders:

--- a/webapp/orders/constants.py
+++ b/webapp/orders/constants.py
@@ -8,6 +8,7 @@ ORDER_STATUS_APPROVED = '2'       # Anfrage ist akzeptiert
 ORDER_STATUS_REJECTED = '3'       # Anfrage ist abgelehnt
 ORDER_STATUS_PU_ASSIGNED = '4'    # Anfrage ist Poweruser zugewiesen
 ORDER_STATUS_PU_ACCEPTED = '5'    # Poweruser hat Anfrage akzeptiert
+ORDER_STATUS_PU_ACTION_REQUIRED = 'pu_action' # Poweruser kann nachtr. die Betreeung nicht wahrnehmen
 ORDER_STATUS_PU_REJECTED = '6'    # Poweruser hat Anfrage abgelehnt
 ORDER_STATUS_CONFIRMED = '7'      # User ist benachrichtigt
 ORDER_STATUS_CANCELLED = '8'      # Anfrage ist storniert

--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -30,6 +30,7 @@ from .constants import (
     ORDER_STATUS_WAITING,
     ORDER_STATUS_PU_ACCEPTED,
     ORDER_STATUS_REJECTED,
+    ORDER_STATUS_PU_ACTION_REQUIRED,
     USER_ROLE_ADMIN,
     ORDER_STATUS_APPROVED,
     ORDER_STATUS_PU_ASSIGNED,
@@ -634,6 +635,31 @@ def approver_assign_poweruser():
   </button>
 </span>
 """
+
+# --------------------------------------------------------------------
+# Termin kann nicht wahrgenommen werden
+# --------------------------------------------------------------------
+
+@orders.route("/poweruser/cannot_take_order", methods=["POST"])
+@login_required
+def poweruser_cannot_take_order():
+    order_id = int(request.form["order_id"])
+    note = request.form.get("poweruser_note", "").strip()
+
+    order = ObservationRequest.query.get_or_404(order_id)
+
+    # nur der zugewiesene Poweruser darf den Antrag zurückgeben
+    if order.request_poweruser_id != current_user.id:
+        abort(403)
+
+    order.status = ORDER_STATUS_PU_ACTION_REQUIRED
+    order.poweruser_feedback = note
+    order.poweruser_feedback_at = datetime.utcnow()
+
+    db.session.commit()
+
+    flash("Der Antrag wurde an den Genehmiger zur erneuten Bearbeitung zurückgegeben.", "warning")
+    return redirect(url_for("main.poweruser"))
 
 # --------------------------------------------------------------------
 # Der Kontrolleur (Approver) weist Antrag zurück

--- a/webapp/templates/approver.html
+++ b/webapp/templates/approver.html
@@ -13,6 +13,15 @@
 
 {% if orders|length > 0 %}
 
+{% if order.status == ORDER_STATUS_PU_ACTION_REQUIRED %}
+    <span class="badge bg-danger">Action required</span>
+    {% if order.poweruser_feedback %}
+        <div class="small text-muted mt-1">
+            Rückmeldung Poweruser: {{ order.poweruser_feedback }}
+        </div>
+    {% endif %}
+{% endif %}
+
 <table class="table table-bordered table-striped table-hover">
     <thead>
         <tr>

--- a/webapp/templates/approver.html
+++ b/webapp/templates/approver.html
@@ -13,15 +13,6 @@
 
 {% if orders|length > 0 %}
 
-{% if order.status == ORDER_STATUS_PU_ACTION_REQUIRED %}
-    <span class="badge bg-danger">Action required</span>
-    {% if order.poweruser_feedback %}
-        <div class="small text-muted mt-1">
-            Rückmeldung Poweruser: {{ order.poweruser_feedback }}
-        </div>
-    {% endif %}
-{% endif %}
-
 <table class="table table-bordered table-striped table-hover">
     <thead>
         <tr>
@@ -39,6 +30,14 @@
     </thead>
     <tbody>
     {% for order in orders %}
+    {% if order.status == ORDER_STATUS_PU_ACTION_REQUIRED %}
+    <span class="badge bg-danger">Action required</span>
+    {% if order.poweruser_feedback %}
+        <div class="small text-muted mt-1">
+            Rückmeldung Poweruser: {{ order.poweruser_feedback }}
+        </div>
+    {% endif %}
+{% endif %}
         <tr>
             <td>
                 <a href="{{ url_for('orders.show_order_positions', order_id=order.id) }}" class="btn btn-sm btn-secondary" title="Show">

--- a/webapp/templates/poweruser.html
+++ b/webapp/templates/poweruser.html
@@ -54,10 +54,7 @@
   <option value="3" {% if order.my_pu_meldung_availability == 3 %}selected{% endif %}>Nicht möglich</option>
 </select>
 
-<form method="post" action="{{ url_for('orders.poweruser_cannot_take_order') }}">
-    <input type="hidden" name="order_id" value="{{ order.id }}">
-    <textarea name="poweruser_note" class="form-control"
-              placeholder="Optionaler Hinweis für den Genehmiger"></textarea>
+<form method="post" action="{{ url_for('orders.poweruser_cannot_take_order') }}">    
     <button type="submit" class="btn btn-warning mt-2">
         Kann Termin nicht wahrnehmen
     </button>

--- a/webapp/templates/poweruser.html
+++ b/webapp/templates/poweruser.html
@@ -54,6 +54,15 @@
   <option value="3" {% if order.my_pu_meldung_availability == 3 %}selected{% endif %}>Nicht möglich</option>
 </select>
 
+<form method="post" action="{{ url_for('orders.poweruser_cannot_take_order') }}">
+    <input type="hidden" name="order_id" value="{{ order.id }}">
+    <textarea name="poweruser_note" class="form-control"
+              placeholder="Optionaler Hinweis für den Genehmiger"></textarea>
+    <button type="submit" class="btn btn-warning mt-2">
+        Kann Termin nicht wahrnehmen
+    </button>
+</form>
+
 <button type="button" class="btn btn-sm btn-outline-primary"
         hx-post="{{ url_for('main.poweruser') }}"
         hx-include="#action-{{ order.id }},#order-{{ order.id }},#availability-{{ order.id }}{% if csrf_token is defined %},#csrf_token{% endif %}"


### PR DESCRIPTION
Nach Issue #93 ist die Ergänzung des Absagebuttons für eine angenommene Betreuung hinzugekommen. Der Approver erhält dabei auch die entsprechende Meldung.

Geändert ist dabei:

- webapp/orders/constants.py
Neuer Status eingefügt (ORDER_STATUS_PU_ACTION_REQUIRED = 'pu_action'), dabei bei ORDER_STATUS_LABELS ergänzt:
'pu_action': 'Action required'

- webapp/orders/routes.py
@orders.route('/poweruser/<int:order_id>/pu_action_required', methods=['POST'])

- webapp/main/routes.py
 Anpassung des Approverbereichs (neuer Status 'pu_action' und Sortierung

- poweruser.html
Neuer Button ergänzt 'Kann Termin nicht wahrnehmen' mit entsprechender Info an Route und Backendstatus

- approver.html
Anzeige des neuen Status