### PR TITLE
Nr125-Approver-Seite-ist-als-Normalnutzer-aufrufbar

### DIFF
--- a/webapp/main/routes.py
+++ b/webapp/main/routes.py
@@ -12,6 +12,7 @@ from webapp.orders.constants import USER_ROLE_ADMIN, USER_ROLE_APPROVER, USER_RO
 from webapp.orders.constants import ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED
 from sqlalchemy.exc import IntegrityError
 from collections import defaultdict
+from ..users.utils import role_required
 
 @main.route("/")
 @main.route("/home")
@@ -51,6 +52,7 @@ def home():
 # -------------------------------------------------------------
 @main.route("/poweruser", methods=['GET','POST'])
 @login_required
+@role_required("poweruser")
 def poweruser():
 
     if request.method == "POST":
@@ -121,6 +123,7 @@ def poweruser():
 # -------------------------------------------------------------
 @main.route("/approver", methods=["GET"])
 @login_required
+@role_required("approver")
 def approver():
 
     all_orders = (

--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -569,6 +569,7 @@ def show_order_positions(order_id):
 # --------------------------------------------------------------------
 @orders.route("/poweruser/<int:order_id>/pu_accept", methods=["POST"])
 @login_required
+@role_required("poweruser")
 def pu_accept(order_id):
     order_head = ObservationRequest.query.get(order_id)
     order_head.status = ORDER_STATUS_PU_ACCEPTED
@@ -656,6 +657,7 @@ def approver_assign_poweruser():
 # --------------------------------------------------------------------
 @orders.route("/approver/<int:order_id>/reject", methods=["POST"])
 @login_required
+@role_required("approver")
 def reject_order(order_id):
     order_head = ObservationRequest.query.get(order_id)
     order_head.status = ORDER_STATUS_REJECTED
@@ -680,6 +682,7 @@ def reject_order(order_id):
 # --------------------------------------------------------------------
 @orders.route("/approver/<int:order_id>/approve", methods=["POST"])
 @login_required
+@role_required("approver")
 def approve_order(order_id):
     order_head = ObservationRequest.query.get(order_id)
     order_head.status = ORDER_STATUS_APPROVED
@@ -697,6 +700,7 @@ def approve_order(order_id):
 
 @orders.route("/approver/assign_poweruser_form", methods=["GET"])
 @login_required
+@role_required("approver")
 def approver_assign_poweruser_form():
     order_id = request.args.get("order_id", type=int)
     if not order_id:


### PR DESCRIPTION
#125 
Folgende Anpassungen wurde durchgeführt angegeben ist die Datei bzw. die jeweilige Zeilennummer

# Webapp/order/routes.py

**Poweruser weist sich Antrag zu**
@orders.route("/poweruser/<int:order_id>/pu_accept", methods=["POST"]
@login_required
**Zeile 572
@role_required("poweruser")**

**Der Kontrolleur (Approver) weist Antrag zurück**
@orders.route("/approver/<int:order_id>/reject", methods=["POST"])
@login_required
**Zeile 660
@role_required("approver")**

**Der Kontrolleur (Approver) akzeptiert Antrag**
@orders.route("/approver/<int:order_id>/approve", methods=["POST"])
@login_required
**Zeile 685
@role_required("approver")**


@orders.route("/approver/assign_poweruser_form", methods=["GET"])
@login_required
**Zeile 703
@role_required("approver")**


# Webapp/main/routes.py

**Zeile 15
from ..users.utils import role_required**

@main.route("/poweruser", methods=['GET','POST'])
@login_required
**Zeile 55
@role_required("poweruser")**

@main.route("/approver", methods=["GET"])
@login_required
**Zeile 125
@role_required("approver")**


