### PR TITLE
113 Zugriff Kalender angepasst

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -842,6 +842,8 @@ def send_reject_email(order_id, approver_id,order_url):
 # Belegungskalender anzeigen
 # --------------------------------------------------------------------
 @orders.route("/orders/show_calendar", methods=["GET"])
+@login_required
+@role_required("user")
 def show_calendar():
     year = request.args.get("year", default=datetime.now().year, type=int)
     month = request.args.get("month", default=datetime.now().month, type=int)


### PR DESCRIPTION
Nach Issue 113 ist der Zugriff auf den Kalender ohne angemeldeter Benutzer möglich

Dies ist nun mit dieser Anpassung in routes.py entsprechend der Rollenbeschreibung geändert worden