### PR TITLE
F-02: Zugriff auf Beobachtungsantrags-Gesamtliste beschränken

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -925,6 +925,7 @@ def show_calendar():
 
 @orders.route("/obs_requests")
 @login_required
+@role_required("approver")
 def obs_request_complete():
     orders = ObservationRequest.query.order_by(ObservationRequest.id.desc()).all()
 


### PR DESCRIPTION
## Änderung

Dieser PR beschränkt die Gesamtliste der Beobachtungsanträge auf Approver/Admin.

- Ergänzt `@role_required("approver")` an `/obs_requests`.
- Admins bleiben durch die bestehende `role_required`-Implementierung weiterhin erlaubt.

## Warum

Die Route war bisher nur mit `@login_required` geschützt. Dadurch konnte jeder eingeloggte Benutzer die Gesamtliste aller Beobachtungsanträge öffnen und fremde Antragsdaten sehen.

Fixes #192

## Prüfung

- `python -m compileall -q webapp datamigrations migrations`
- AST-Prüfung, dass `obs_request_complete` sowohl `@login_required` als auch `@role_required("approver")` trägt.

## Abgrenzung

Dieser PR behebt gezielt F-02. Weitere Befunde wie Statusänderungen, CSRF-Schutz oder Poweruser-Zuweisungen sind bewusst nicht Teil dieses Pull Requests.

Geschrieben und eingestellt mit KI Codex
