### PR TITLE
F-03: Bearbeitung auf editierbare Antragsstatus beschränken

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -260,7 +260,11 @@ def edit_order_pos(order_id):
     order_head = ObservationRequest.query.get(order_id)
     if order_head is None:
         abort(403)
-    if order_head.user_id != current_user.id and not current_user.has_role(USER_ROLE_ADMIN):
+
+    is_admin = current_user.has_role(USER_ROLE_ADMIN)
+    if order_head.user_id != current_user.id and not is_admin:
+        abort(403)
+    if not is_admin and order_head.status not in {ORDER_STATUS_CREATED, ORDER_STATUS_REJECTED}:
         abort(403)
 
     expert_mode = get_user_preference_service(current_user.id, "expert_mode", "False")


### PR DESCRIPTION
## Änderung

Dieser PR blockiert die direkte Bearbeitung eigener Anträge, sobald sie nicht mehr in einem bearbeitbaren Status sind.

- Ermittelt in `edit_order_pos` einmalig `is_admin`.
- Besitzer dürfen eigene Anträge nur noch in `ORDER_STATUS_CREATED` oder `ORDER_STATUS_REJECTED` bearbeiten.
- Admins behalten die bisherige Korrekturmöglichkeit.
- Nicht berechtigte Zugriffe werden mit `403 Forbidden` beendet.

## Warum

Die Route prüfte bisher nur Besitzer/Admin, aber nicht den fachlichen Status. Dadurch konnten normale Benutzer eigene bereits eingereichte oder genehmigte Anträge per direktem URL-/POST-Aufruf nachträglich verändern.

Fixes #194

## Prüfung

- `python -m compileall -q webapp datamigrations migrations`
- AST-Prüfung, dass `edit_order_pos` den Status-Wächter enthält.

## Abgrenzung

Dieser PR behebt gezielt F-03. Löschregeln, CSRF-Schutz und Poweruser-/Approver-Aktionen sind bewusst nicht Teil dieses Pull Requests.

Geschrieben und eingestellt mit KI Codex
