### PR TITLE
F-04: Löschen auf erlaubte Antragsstatus beschränken

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -157,6 +157,8 @@ def delete_order(order_id):
     order = ObservationRequest.query.get_or_404(order_id)
     if order.user_id != current_user.id:
         abort(403)
+    if order.status not in {ORDER_STATUS_CREATED, ORDER_STATUS_REJECTED}:
+        abort(403)
 
     rc, message = delete_order_service(order_id)
     flash(message, "success" if rc == 0 else "danger")


### PR DESCRIPTION
## Änderung

Dieser PR beschränkt das Löschen eigener Beobachtungsanträge auf löschbare Status.

- `delete_order` erlaubt das Löschen nur noch bei `ORDER_STATUS_CREATED` oder `ORDER_STATUS_REJECTED`.
- Für spätere Workflow-Status wird vor dem Service-Aufruf `403 Forbidden` ausgelöst.

## Warum

Die Route prüfte bisher nur den Besitzer, aber nicht den Status. Dadurch konnten normale Benutzer eigene bereits eingereichte, genehmigte oder zugewiesene Anträge per direktem POST löschen.

Fixes #196

## Prüfung

- `python -m compileall -q webapp datamigrations migrations`
- AST-Prüfung, dass der Status-Wächter vor `delete_order_service(order_id)` steht.

## Abgrenzung

Dieser PR behebt gezielt F-04. Ein späterer fachlicher Storno-/Cancel-Workflow wäre sinnvoll, ist aber bewusst nicht Teil dieser kleinen Sicherheitskorrektur.

Geschrieben und eingestellt mit KI Codex
