### PR TITLE
F-05: Enable CSRF protection for POST actions

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -5,6 +5,7 @@ from flask_bcrypt import Bcrypt
 from flask_login import LoginManager
 from flask_mail import Mail
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf.csrf import CSRFProtect
 from sqlalchemy import MetaData
 #import jinja_partials
 from celery import Celery, Task
@@ -20,6 +21,7 @@ login_manager.login_message_category = 'info'
 login_manager.session_protection = "strong"
 mail = Mail()
 admin = Admin()
+csrf = CSRFProtect()
 
 db = SQLAlchemy(add_models_to_shell=True,
                 metadata=MetaData(naming_convention={
@@ -85,6 +87,7 @@ def create_app(config_class=Config):
     bcrypt.init_app(app)
     login_manager.init_app(app)
     mail.init_app(app)
+    csrf.init_app(app)
     init_admin(app, admin) # setup admin views
 
     @app.before_request

--- a/webapp/main/templates/approver.html
+++ b/webapp/main/templates/approver.html
@@ -54,11 +54,13 @@
                     </a>                    
                 
                  <form method="post" action="{{ url_for('orders.approve_order', order_id=order.id) }}" style="display:inline;" onsubmit="return confirm('Du willst diesen neuen Antrag genehmigen?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                       <button type="submit" class="btn btn-sm btn-success" title="Genehmingen">
                       <i class="bi bi-hand-thumbs-up-fill"></i>
                       </button>
                     </form>
                      <form method="post" action="{{ url_for('orders.reject_order', order_id=order.id) }}" style="display:inline;" onsubmit="return confirm('Du willst diesen neuen Antrag zurückweisen?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                       <button type="submit" class="btn btn-sm btn-danger" title="Ablehnen">
                       <i class="bi bi-hand-thumbs-down"></i>
                       </button>
@@ -249,6 +251,7 @@
   {% endif %}
 
 <form method="post" action="{{ url_for('main.poweruser') }}">
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
 {% endif %}
 <a class="btn btn-warning" style="background-color: #007bff; color: white;" href="{{ url_for('main.home') }}" >Zur Startseite</a>

--- a/webapp/main/templates/gast.html
+++ b/webapp/main/templates/gast.html
@@ -28,6 +28,7 @@
       <tr>
         <td>
             <form method="POST" action="{{ url_for('main.gast_approve') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input type="hidden" name="user_id" value="{{ u.id }}">
             <button class="btn btn-success btn-sm" type="submit">Freischalten</button>
           </form></td>

--- a/webapp/orders/templates/create_order.html
+++ b/webapp/orders/templates/create_order.html
@@ -3,6 +3,7 @@
 
 <h2>Teleskopzeit Neu beantragen</h2>
 <form method="post" action="{{ url_for('orders.actionhandler') }}">
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 {% if current_user.is_authenticated %}
 <p>Antragssteller: {{ current_user.firstname }} {{ current_user.surname }} ({{ current_user.name }})</p>
 

--- a/webapp/orders/templates/edit_order_pos.html
+++ b/webapp/orders/templates/edit_order_pos.html
@@ -501,7 +501,10 @@ function registerTelescopeBoxListeners(context = document) {
 
       fetch('/orders/get_filtersets', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': document.querySelector('meta[name="csrf-token"]').content
+        },
         body: JSON.stringify({ telescope_id: this.value })
       })
       .then(r => r.json())

--- a/webapp/orders/templates/obs_request_complete.html
+++ b/webapp/orders/templates/obs_request_complete.html
@@ -36,6 +36,7 @@
                       action="{{ url_for('orders.approve_order', order_id=order.id) }}"
                       style="display:inline;"
                       onsubmit="return confirm('Du willst diesen genehmigen?');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-sm btn-success" title="Genehmigen">
                         <i class="bi bi-hand-thumbs-up-fill"></i>
                     </button>
@@ -45,6 +46,7 @@
                       action="{{ url_for('orders.reject_order', order_id=order.id) }}"
                       style="display:inline;"
                       onsubmit="return confirm('Du willst diesen Antrag zurückweisen?');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                     <button type="submit" class="btn btn-sm btn-danger" title="Ablehnen">
                         <i class="bi bi-hand-thumbs-down"></i>
                     </button>

--- a/webapp/orders/templates/orders.html
+++ b/webapp/orders/templates/orders.html
@@ -38,6 +38,7 @@
                         <i class="bi bi-pencil"></i>
                     </a>
                     <form method="post" action="{{ url_for('orders.delete_order', order_id=order.id) }}" style="display:inline;" onsubmit="return confirm('Echt jetzt?\n wirklich löschen?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                       <button type="submit" class="btn btn-sm btn-danger" title="Delete">
                       <i class="bi bi-trash"></i>
                       </button>
@@ -75,6 +76,7 @@
 <br>
 
 <form method="post" action="{{ url_for('orders.actionhandler') }}">
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
 <button type="submit" class="btn btn-success" name="action" value="create_order">
       Neuen Antrag eingeben

--- a/webapp/posts/templates/post.html
+++ b/webapp/posts/templates/post.html
@@ -30,6 +30,7 @@
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           <form action="{{ url_for('posts.delete_post', post_id=post.id) }}" method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <input class="btn btn-danger" type="submit" value="Delete">
           </form>
         </div>

--- a/webapp/templates/admin/index.html
+++ b/webapp/templates/admin/index.html
@@ -24,6 +24,7 @@
                     <h2>Export</h2>
                     <p>Exportiere Datenbank in JSON Datei.</p>
                     <form action="{{ url_for('inout.export_data') }}" method="post">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <button type="submit" class="btn btn-primary">Export</button>
                     </form>
                 </div>
@@ -31,6 +32,7 @@
                     <h2>Import</h2>
                     <p>Importiere Datenbank aus JSON Datei.</p>
                     <form action="{{ url_for('inout.import_data') }}" method="post" enctype="multipart/form-data">
+                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                         <div class="form-group">
                             <label for="file">Datei</label>
                             <input type="file" class="form-control-file" id="file" name="file">

--- a/webapp/templates/layout.html
+++ b/webapp/templates/layout.html
@@ -9,11 +9,20 @@
     <link href="{{ url_for('static', filename='bootstrap-5.3.3.min.css')}}" rel="stylesheet" integrity="sha384-J7XvR9bYiQw3uAsOM+Fb6h8cviYhGfsktO93j9pyeHxh69xwDyB0VYmszxrzafbC" crossorigin="anonymous">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='bootstrap-icons/font/bootstrap-icons.css') }}">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <script defer src="{{ url_for('static', filename='htmx-2.0.3.min.js') }}"></script>
     <script defer src="{{ url_for('static', filename='jquery-3.2.1.slim.min.js') }}" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script defer src="{{ url_for('static', filename='bootstrap.bundle-5.3.3.min.js') }}" integrity="sha384-5FgqaIraNQm5MiWvLwoH1jzRCUDttx0J35wHBQRUt37DNCv+XDWYJVYdri0f/Qfa" crossorigin="anonymous"></script>
     <!-- our styles and scripts -->
     <script defer src="{{ url_for('static', filename='darkmode.js') }}"></script>
+    <script>
+        document.addEventListener("htmx:configRequest", function (event) {
+            var token = document.querySelector('meta[name="csrf-token"]');
+            if (token) {
+                event.detail.headers["X-CSRFToken"] = token.content;
+            }
+        });
+    </script>
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='main.css') }}">
 
     {% if title %}


### PR DESCRIPTION
## Zusammenfassung

- aktiviert `CSRFProtect` fuer die Flask-Anwendung
- ergaenzt CSRF-Tokens in zustandsaendernden Formularen ohne WTForms-`hidden_tag()`
- sendet `X-CSRFToken` fuer HTMX-Requests zentral aus dem Layout
- sendet `X-CSRFToken` fuer den JSON-POST auf `/orders/get_filtersets`

Closes #198

## Tests

- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statischer Formular-/HTMX-/Fetch-Check auf CSRF-Abdeckung

Geschrieben und eingestellt mit KI Codex
