### PR TITLE
F-06: Restrict poweruser acceptance to assigned requests

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -612,7 +612,13 @@ def show_order_positions(order_id):
 @login_required
 @role_required("poweruser")
 def pu_accept(order_id):
-    order_head = ObservationRequest.query.get(order_id)
+    order_head = ObservationRequest.query.get_or_404(order_id)
+    if (
+        order_head.status != ORDER_STATUS_PU_ASSIGNED
+        or order_head.request_poweruser_id != current_user.id
+    ):
+        abort(403)
+
     order_head.status = ORDER_STATUS_PU_ACCEPTED
     try:
         db.session.commit()


### PR DESCRIPTION
## Zusammenfassung

- schuetzt `pu_accept` gegen nicht vorhandene Antraege mit `get_or_404`
- erlaubt die Statusaenderung zu `PU_ACCEPTED` nur fuer `PU_ASSIGNED`
- verlangt, dass der aktuell angemeldete Poweruser dem Antrag tatsaechlich zugewiesen ist
- weist alle anderen direkten POSTs mit `403` ab

Closes #200

## Tests

- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statischer AST-/Quelltextcheck fuer die Guard-Reihenfolge in `pu_accept`

Geschrieben und eingestellt mit KI Codex
