### PR TITLE
F-16: Waitress-Proxy-Vertrauen explizit konfigurieren

### DIFF
--- a/prod.py
+++ b/prod.py
@@ -9,13 +9,35 @@ app = create_app()
 
 from waitress import serve
 from paste.translogger import TransLogger
+
+
+def env_bool(name, default=False):
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in ('true', '1', 't')
+
+
 # see: https://docs.pylonsproject.org/projects/waitress/en/stable/arguments.html
-serve(TransLogger(app, setup_console_handler=(os.getenv('SETUP_CONSOLE_HANDLER', 'false').lower() in ('true', '1', 't'))),
-    listen=os.getenv('LISTEN', '0.0.0.0:5000'),
-    url_scheme=os.getenv('URL_SCHEMA', 'https'),
-    threads=int(os.getenv('THREADS','4')),
-    trusted_proxy_count=int(os.getenv('TRUSTED_PROXY_COUNT', '1')), # trust only one proxy, set to 0 when not using proxy
-    trusted_proxy=os.getenv('TRUSTED_PROXY', '*'), # trust all proxies, if IP of proxy can change
-    trusted_proxy_headers=os.getenv('TRUSTED_PROXY_HEADERS', 'x-forwarded-for x-forwarded-host x-forwarded-proto x-forwarded-port'),
-    log_untrusted_proxy_headers=(os.getenv('LOG_UNTRUSTED_PROXY_HEADERS', 'true').lower() in ('true', '1', 't'))
-    )
+waitress_options = {
+    'listen': os.getenv('LISTEN', '0.0.0.0:5000'),
+    'url_scheme': os.getenv('URL_SCHEMA', 'https'),
+    'threads': int(os.getenv('THREADS', '4')),
+}
+
+trusted_proxy = os.getenv('TRUSTED_PROXY')
+if trusted_proxy:
+    waitress_options.update({
+        'trusted_proxy': trusted_proxy,
+        'trusted_proxy_count': int(os.getenv('TRUSTED_PROXY_COUNT', '1')),
+        'trusted_proxy_headers': os.getenv(
+            'TRUSTED_PROXY_HEADERS',
+            'x-forwarded-for x-forwarded-host x-forwarded-proto x-forwarded-port',
+        ),
+        'log_untrusted_proxy_headers': env_bool('LOG_UNTRUSTED_PROXY_HEADERS', True),
+    })
+
+serve(
+    TransLogger(app, setup_console_handler=env_bool('SETUP_CONSOLE_HANDLER', False)),
+    **waitress_options,
+)


### PR DESCRIPTION
## Änderung

- Waitress-Optionen in `prod.py` explizit als Dictionary aufgebaut
- `trusted_proxy*`-Optionen nur noch gesetzt, wenn `TRUSTED_PROXY` in der Umgebung vorhanden ist
- kleinen `env_bool`-Helper für vorhandene Bool-Umgebungsvariablen ergänzt

## Warum

Der bisherige Default `TRUSTED_PROXY=*` vertraut allen Remote-Peers. Proxy-Header sollten in Produktion nur aus bewusst konfigurierten, vertrauenswürdigen Quellen akzeptiert werden.

## Validierung

- `python -m py_compile prod.py`
- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statische Prüfung, dass `os.getenv('TRUSTED_PROXY', '*')` entfernt wurde und `trusted_proxy` nur bei expliziter Umgebungskonfiguration gesetzt wird

Fixes #207

Geschrieben und eingestellt mit KI Codex