### PR TITLE
F-15: Secure-Flag für Session-Cookies konfigurierbar machen

### DIFF
--- a/webapp/__init__.py
+++ b/webapp/__init__.py
@@ -55,7 +55,7 @@ def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
     app.config.update(
-        SESSION_COOKIE_SECURE=False, # needs to be false, so we can run without https locally
+        SESSION_COOKIE_SECURE=app.config.get("SESSION_COOKIE_SECURE", False),
         SESSION_COOKIE_HTTPONLY=True,
         SESSION_COOKIE_SAMESITE='Lax',
     )

--- a/webapp/config.py
+++ b/webapp/config.py
@@ -4,6 +4,18 @@ import os
 with open('config.json') as config_file:
     config = json.load(config_file)
 
+
+def config_bool(name, default=False):
+    value = os.environ.get(name, config.get(name))
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).lower() in ('true', '1', 't', 'yes', 'y', 'on')
+
+
 class Config:
     SECRET_KEY = config.get('SECRET_KEY')
     SQLALCHEMY_DATABASE_URI = config.get('SQLALCHEMY_DATABASE_URI')
@@ -26,3 +38,7 @@ class Config:
     GITCOMMIT=os.environ.get('GITCOMMIT', '')
     CLEANBUILD=os.environ.get('CLEANBUILD', '')
     ENVIRONMENT = config.get('ENVIRONMENT', 'LOCAL')
+    SESSION_COOKIE_SECURE = config_bool(
+        'SESSION_COOKIE_SECURE',
+        default=str(ENVIRONMENT).upper() == 'PRODUCTION',
+    )


### PR DESCRIPTION
## Änderung

- `config_bool()` zum Lesen von booleschen Werten aus `config.json` oder Umgebung ergänzt
- `SESSION_COOKIE_SECURE` in `Config` ergänzt
- Produktionsdefault: `ENVIRONMENT=PRODUCTION` setzt `SESSION_COOKIE_SECURE=True`
- App-Fabrik verwendet den konfigurierten Wert statt hart codiertem `False`

## Warum

Session-Cookies sollten im Produktivbetrieb per Secure-Flag auf HTTPS beschränkt werden. Der bisherige feste Wert machte das unabhängig von der Umgebung unmöglich.

## Validierung

- `python -m py_compile webapp\config.py webapp\__init__.py`
- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statische Prüfung, dass `SESSION_COOKIE_SECURE=False` aus der App-Fabrik entfernt und der Produktionsdefault ergänzt wurde

Fixes #209

Geschrieben und eingestellt mit KI Codex