### PR TITLE
F-20: Exception-Details aus Benutzerfehlermeldungen entfernen

### DIFF
--- a/webapp/orders/orderservices.py
+++ b/webapp/orders/orderservices.py
@@ -1,3 +1,4 @@
+from flask import current_app
 from flask_login import current_user
 from datetime import datetime, timedelta
 from webapp.model.db import Catalogue
@@ -103,9 +104,10 @@ def copy_order_service(order_id):
 
         try:
             db.session.commit()
-        except Exception as e:
+        except Exception:
             db.session.rollback()
-            return 1, f'Es ist ein Fehler aufgetreten:\n{e}.\nBitte melden Sie sich beim Systemadministrator.'
+            current_app.logger.exception("Failed to copy order")
+            return 1, 'Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.'
         return 0, "Antrag \nerfolgreich\n kopiert."
 
 
@@ -122,9 +124,10 @@ def delete_order_service(order_id):
             db.session.commit()
         db.session.delete(order)
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return 1, f'Es ist ein Fehler aufgetreten:\n{e}.\nBitte melden Sie sich beim Systemadministrator.'
+        current_app.logger.exception("Failed to delete order")
+        return 1, 'Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.'
     return 0, "Antrag \nerfolgreich\n gelöscht."
 
 # --------------------------------------------------------------------------
@@ -200,9 +203,10 @@ def set_user_preference_service( user_id, key, value, default=None ):
     pref.value = str(value)
     try:
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        return 1, f'Es ist ein Fehler aufgetreten:\n{e}.\nBitte melden Sie sich beim Systemadministrator.'
+        current_app.logger.exception("Failed to save user preference")
+        return 1, 'Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.'
     return 0, None
 
 

--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -496,9 +496,10 @@ def edit_order_pos(order_id):
                 return redirect (url_for("orders.edit_order_pos", order_id=order_id))
             # kein 'return' wenn "save_order"
 
-        except Exception as e:
+        except Exception:
             db.session.rollback()
-            flash(f"Es ist ein Fehler aufgetreten: {e}", "danger")
+            current_app.logger.exception("Failed to save order positions")
+            flash("Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.", "danger")
             return redirect(url_for("orders.edit_order_pos", order_id=order_id))
 
     # -------------------------
@@ -560,10 +561,11 @@ def edit_order_pos(order_id):
         order_head.status = ORDER_STATUS_WAITING
         try:
             db.session.commit()
-        except Exception as e:
+        except Exception:
             db.session.rollback()
+            current_app.logger.exception("Failed to submit order")
             flash(
-                f"Es ist ein Fehler aufgetreten: {e}. Bitte melden Sie sich beim Systemadministrator.",
+                "Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.",
                 "danger",
             )
         # freeze reservation
@@ -573,8 +575,8 @@ def edit_order_pos(order_id):
                 reservation.freeze()
                 db.session.add(reservation)
                 db.session.commit()
-            except Exception as e:
-                print(f"Es ist ein Fehler aufgetreten: {e}.")
+            except Exception:
+                current_app.logger.exception("Failed to freeze reservation")
                 db.session.rollback()
                 flash(
                     f"Die reservation ist bereits abgelaufen und kann nicht mehr aufrechterhalten werden",
@@ -616,10 +618,11 @@ def pu_accept(order_id):
     order_head.status = ORDER_STATUS_PU_ACCEPTED
     try:
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
+        current_app.logger.exception("Failed to accept order as poweruser")
         flash(
-            f"Es ist ein Fehler aufgetreten: {e}. Bitte melden Sie sich beim Systemadministrator.",
+            "Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.",
             "danger",
         )
     else:
@@ -646,9 +649,9 @@ def approver_assign_poweruser():
         order.status = ORDER_STATUS_PU_ASSIGNED
         db.session.add(order)
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
-        print(f"Es ist ein Fehler aufgetreten: {e}.")
+        current_app.logger.exception("Failed to assign poweruser")
 
     reservation = ObservatoryReservation.query.filter_by(observation_request_id=order_id).first();
     if reservation:
@@ -656,8 +659,8 @@ def approver_assign_poweruser():
             reservation.confirm()
             db.session.add(reservation)
             db.session.commit()
-        except Exception as e:
-            print(f"Es ist ein Fehler aufgetreten: {e}.")
+        except Exception:
+            current_app.logger.exception("Failed to confirm reservation after assigning poweruser")
             db.session.rollback()
 
     pu_user = User.query.get(poweruser_user_id)
@@ -741,10 +744,11 @@ def approve_order(order_id):
     order_head.status = ORDER_STATUS_APPROVED
     try:
         db.session.commit()
-    except Exception as e:
+    except Exception:
         db.session.rollback()
+        current_app.logger.exception("Failed to approve order")
         flash(
-            f"Es ist ein Fehler aufgetreten: {e}. Bitte melden Sie sich beim Systemadministrator.",
+            "Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.",
             "danger",
         )
     else:

--- a/webapp/users/routes.py
+++ b/webapp/users/routes.py
@@ -1,4 +1,4 @@
-from flask import render_template, url_for, flash, redirect, request
+from flask import current_app, render_template, url_for, flash, redirect, request
 from flask_login import login_user, current_user, logout_user, login_required
 from urllib.parse import urlparse
 from webapp import bcrypt, db
@@ -42,9 +42,10 @@ def register():
 
         try:
             db.session.commit()
-        except Exception as e:
+        except Exception:
             db.session.rollback()
-            flash(f"Es ist ein Fehler aufgetreten: {e}. Bitte melden Sie sich beim Systemadministrator.", "error")
+            current_app.logger.exception("Failed to register user")
+            flash("Es ist ein Fehler aufgetreten. Bitte melden Sie sich beim Systemadministrator.", "error")
             return render_template("register.html", title="Register", form=form)
 
         flash("Ihr Benutzer ist registriert! Sie können sich jetzt anmelden", "success")


### PR DESCRIPTION
## Änderung

- konkrete Exception-Texte aus mehreren `flash(...)`-Meldungen entfernt
- Service-Rückgaben entschärft, die vorher Exception-Details enthalten konnten
- Fehlerdetails mit `current_app.logger.exception(...)` serverseitig protokolliert
- einfache `print(...)`-Ausgaben mit Exception-Text ebenfalls auf Logger umgestellt

## Warum

Roh-Exceptions können interne Details offenlegen und Nutzern technische Informationen anzeigen, die nicht für die Oberfläche bestimmt sind.

## Validierung

- `python -m py_compile webapp\users\routes.py webapp\orders\routes.py webapp\orders\orderservices.py`
- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statische Prüfung, dass die geprüften Dateien keine user-sichtbaren `{e}`-Fehlermeldungen mehr enthalten und stattdessen Logger-Aufrufe nutzen

Fixes #211

Geschrieben und eingestellt mit KI Codex