### PR TITLE
F-08: Poweruser-Rückmeldungen serverseitig autorisieren

### DIFF
--- a/webapp/main/routes.py
+++ b/webapp/main/routes.py
@@ -15,6 +15,14 @@ from collections import defaultdict
 from ..users.utils import role_required
 from sqlalchemy import or_, and_
 
+def can_save_poweruser_meldung(order):
+    if order.status == ORDER_STATUS_APPROVED:
+        return True
+    return (
+        order.status == ORDER_STATUS_PU_ASSIGNED
+        and order.request_poweruser_id == current_user.id
+    )
+
 @main.route("/")
 @main.route("/home")
 def home():
@@ -68,6 +76,13 @@ def poweruser():
             return (
                 f'<span id="pu-feedback-{order_id or 0}" class="text-danger ms-2">Ungültige Eingabe</span>',
                 400,
+            )
+
+        order = ObservationRequest.query.get(order_id)
+        if order is None or not can_save_poweruser_meldung(order):
+            return (
+                f'<span id="pu-feedback-{order_id or 0}" class="text-danger ms-2">Keine Berechtigung für diesen Antrag</span>',
+                403,
             )
 
         meldung = PoweruserMeldung.query.filter_by(


### PR DESCRIPTION
## Änderung

- `can_save_poweruser_meldung(order)` ergänzt
- POST `/poweruser` lädt den Antrag vor dem Speichern
- nicht vorhandene oder fachlich nicht erlaubte `order_id` liefert 403
- erlaubte Fälle bleiben: offene genehmigte Anträge und eigene zugewiesene Anträge

## Warum

Die bisherige POST-Route akzeptierte eine frei übergebene `order_id` und speicherte Poweruser-Rückmeldungen ohne Objektprüfung.

## Validierung

- `python -m py_compile webapp\main\routes.py`
- `python -m compileall -q webapp datamigrations migrations`
- `git diff --check`
- statische Prüfung, dass die POST-Route vor dem Speichern `can_save_poweruser_meldung(...)` nutzt

Fixes #213

Geschrieben und eingestellt mit KI Codex