### PR TITLE
PU reassignment after withdrawal

### DIFF
--- a/webapp/main/routes.py
+++ b/webapp/main/routes.py
@@ -73,6 +73,12 @@ def poweruser():
                 400,
             )
 
+        order = ObservationRequest.query.get_or_404(order_id)
+
+        is_assigned_to_current_user = (
+        order.status == ORDER_STATUS_PU_ASSIGNED
+        and order.request_poweruser_id == current_user.id
+        )
 
         meldung = PoweruserMeldung.query.filter_by(
             observation_request_id=order_id,
@@ -122,6 +128,10 @@ def poweruser():
             db.session.add(meldung)
         else:
             meldung.availability = availability
+
+# Bereits zugewiesener Poweruser kann den Termin doch nicht wahrnehmen
+        if is_assigned_to_current_user and availability == 3:
+            order.status = ORDER_STATUS_PU_REJECTED
 
         db.session.commit()
 
@@ -209,6 +219,7 @@ def poweruser():
             )
 
             if order.request_poweruser_id == current_user.id:
+                order.my_pu_meldung_availability = my_meldungen_by_order.get(order.id)
                 own_orders.append(order)
             else:
                 others_orders.append(order)
@@ -228,8 +239,18 @@ def approver():
         .filter(ObservationRequest.status.in_([ORDER_STATUS_WAITING, ORDER_STATUS_APPROVED, ORDER_STATUS_PU_ASSIGNED, ORDER_STATUS_PU_REJECTED, ORDER_STATUS_PU_ACCEPTED]))
         .all()
     )
+
+    # Action-required-Anträge ganz nach oben
+    all_orders.sort(
+    key=lambda order: order.status != ORDER_STATUS_PU_REJECTED
+    )
+
     for order in all_orders:
         order.status_label = ORDER_STATUS_LABELS.get(order.status, "??")
+
+        # Zugewiesener Poweruser kann Termin nicht mehr wahrnehmen
+        if order.status == ORDER_STATUS_PU_REJECTED:
+            order.status_label = "Action required"
 
         if order.request_poweruser_id:
             order.poweruser_name = User.query.get(order.request_poweruser_id).display_name()

--- a/webapp/main/templates/approver.html
+++ b/webapp/main/templates/approver.html
@@ -23,6 +23,125 @@
     {% set orders_waiting = orders | selectattr('status', 'equalto', CONSTANTS.ORDER_STATUS_WAITING) | list %}
     {% set orders_approved_open = orders | selectattr('status', 'equalto', CONSTANTS.ORDER_STATUS_APPROVED) | list %}
     {% set orders_pu_assigned = orders | selectattr('status', 'equalto', CONSTANTS.ORDER_STATUS_PU_ASSIGNED) | list %}
+    {% set orders_action_required = orders | selectattr('status', 'equalto', CONSTANTS.ORDER_STATUS_PU_REJECTED) | list %}
+
+{# -------------------- ACTION REQUIRED -------------------- #}
+{% if orders_action_required|length > 0 %}
+
+<h3 class="text-danger">Action required</h3>
+
+<table class="table table-bordered table-striped table-hover">
+    <thead>
+        <tr>
+            <th>Aktion</th>
+            <th>Poweruserauswahl</th>
+            <th>Status</th>
+            <th>Datum</th>
+            <th>Beteiligte</th>
+            <th>Poweruser</th>
+        </tr>
+    </thead>
+
+    <tbody>
+    {% for order in orders_action_required %}
+        <tr>
+            <td>
+                <a href="{{ url_for('orders.show_order_positions', order_id=order.id) }}"
+                   class="btn btn-sm btn-secondary"
+                   title="Show">
+                    <i class="bi bi-eye"></i>
+                </a>
+
+                <a href="{{ url_for('orders.edit_order_pos', order_id=order.id) }}"
+                   class="btn btn-sm btn-primary"
+                   title="Edit">
+                    <i class="bi bi-pencil"></i>
+                </a>
+                    <form method="post" action="{{ url_for('orders.approve_order', order_id=order.id) }}" style="display:inline;" onsubmit="return confirm('Du willst diesen neuen Antrag genehmigen?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                      <button type="submit" class="btn btn-sm btn-success" title="Genehmigen">
+                      <i class="bi bi-hand-thumbs-up-fill"></i>
+                      </button>
+                    </form>
+                     <form method="post" action="{{ url_for('orders.reject_order', order_id=order.id) }}" style="display:inline;" onsubmit="return confirm('Du willst diesen neuen Antrag zurückweisen?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                      <button type="submit" class="btn btn-sm btn-danger" title="Ablehnen">
+                      <i class="bi bi-hand-thumbs-down"></i>
+                      </button>
+                    </form>                  
+                </td>
+            <td>
+    {% set meldungen = pu_meldungen_by_order.get(order.id, []) %}
+
+    {% if meldungen|length == 0 %}
+        <span class="text-muted">Keine Rückmeldungen</span>
+    {% else %}
+
+        <div id="pu-select-{{ order.id }}" class="d-flex flex-column gap-1">
+
+            {% for m in meldungen %}
+                <label class="d-flex align-items-center gap-2">
+
+                    <input
+                        type="radio"
+                        name="poweruser_user_id"
+                        value="{{ m.user_id }}"
+                        class="form-check-input"
+                    >
+
+                    <span>{{ m.name }}</span>
+
+                    {% if m.availability == 1 %}
+                        <span class="badge bg-success">Möglich</span>
+                    {% elif m.availability == 2 %}
+                        <span class="badge bg-warning text-dark">Vielleicht</span>
+                    {% elif m.availability == 3 %}
+                        <span class="badge bg-danger">Nein</span>
+                    {% endif %}
+
+                </label>
+            {% endfor %}
+
+            <span id="pu-assign-slot-{{ order.id }}">
+                <button
+                    type="button"
+                    class="btn btn-sm btn-outline-primary mt-1"
+                    hx-post="{{ url_for('orders.approver_assign_poweruser') }}"
+                    hx-include="#pu-select-{{ order.id }} input, #order-id-{{ order.id }}"
+                    hx-target="#pu-assign-slot-{{ order.id }}"
+                    hx-swap="outerHTML">
+                    Poweruser zuweisen
+                </button>
+            </span>
+
+            <input
+                type="hidden"
+                id="order-id-{{ order.id }}"
+                name="order_id"
+                value="{{ order.id }}"
+            >
+
+        </div>
+
+    {% endif %}
+            </td>
+            <td>
+                <span class="badge bg-danger">Action required</span>
+            </td>
+
+            <td>{{ order.request_date.strftime('%d.%m.%Y') }}</td>
+
+            <td>{{ order.name }}</td>
+
+            <td>{{ order.poweruser_name or '-' }}</td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+
+<br>
+
+{% endif %}
 
     {# -------------------- ABGESCHICKT -------------------- #}
     <h3>von FG Mitglied an Approver abgeschickt</h3>

--- a/webapp/main/templates/poweruser.html
+++ b/webapp/main/templates/poweruser.html
@@ -166,7 +166,7 @@
             <th>Details</th>            
             <th>Datum</th>
             <th>Antragsteller</th>
-            <th>Zugewiesener Poweruser</th>
+            <th>Rückmeldung ändern</th>
         </tr>
     </thead>
 
@@ -180,7 +180,69 @@
             </td>            
             <td>{{ order.request_date.strftime('%d.%m.%Y') }}</td>
             <td>{{ order.name }}</td>
-            <td>{{ order.poweruser_name or '-' }}</td>
+            <td>
+    <div class="mt-2">
+        <input type="hidden"
+               id="action-own-{{ order.id }}"
+               name="action"
+               value="pu_meldung">
+
+        <input type="hidden"
+               id="order-own-{{ order.id }}"
+               name="order_id"
+               value="{{ order.id }}">
+
+        <div class="form-check form-check-inline m-0">
+            <input
+                class="form-check-input availability-green"
+                type="radio"
+                name="availability-own-{{ order.id }}"
+                value="1"
+                {% if order.my_pu_meldung_availability == 1 %}checked{% endif %}
+                hx-post="{{ url_for('main.poweruser') }}"
+                hx-trigger="change"
+                hx-include="#action-own-{{ order.id }},#order-own-{{ order.id }}{% if csrf_token is defined %},#csrf_token{% endif %}"
+                hx-vals='{"availability":"1"}'
+                hx-target="#pu-feedback-own-{{ order.id }}"
+                hx-swap="innerHTML"
+            >
+        </div>
+
+        <div class="form-check form-check-inline m-0">
+            <input
+                class="form-check-input availability-yellow"
+                type="radio"
+                name="availability-own-{{ order.id }}"
+                value="2"
+                {% if order.my_pu_meldung_availability == 2 %}checked{% endif %}
+                hx-post="{{ url_for('main.poweruser') }}"
+                hx-trigger="change"
+                hx-include="#action-own-{{ order.id }},#order-own-{{ order.id }}{% if csrf_token is defined %},#csrf_token{% endif %}"
+                hx-vals='{"availability":"2"}'
+                hx-target="#pu-feedback-own-{{ order.id }}"
+                hx-swap="innerHTML"
+            >
+        </div>
+
+        <div class="form-check form-check-inline m-0">
+            <input
+                class="form-check-input availability-red"
+                type="radio"
+                name="availability-own-{{ order.id }}"
+                value="3"
+                {% if order.my_pu_meldung_availability == 3 %}checked{% endif %}
+                hx-post="{{ url_for('main.poweruser') }}"
+                hx-trigger="change"
+                hx-include="#action-own-{{ order.id }},#order-own-{{ order.id }}{% if csrf_token is defined %},#csrf_token{% endif %}"
+                hx-vals='{"availability":"3"}'
+                hx-target="#pu-feedback-own-{{ order.id }}"
+                hx-swap="innerHTML"
+            >
+        </div>
+
+        <div id="pu-feedback-own-{{ order.id }}"></div>
+    </div>
+</td>
         </tr>
     {% endfor %}
     </tbody>


### PR DESCRIPTION
poweruser.html und approver .html sind erweitert:

poweruser.html hat eine Spalte erhalten, in der der PU seinen zugewiesenen Antrag mittels der Ampel umändern kann.

danach erscheint der Antrag bei approver.html als Top-Level "Action required". 

Dort kann der Approver entweder von den bisherigen Rückmeldungen jemand anderes auswählen, zurück an Pus zur Neuentscheidung senden oder Antrag ablehnen.

Dazu wurden zusätzlich in routes.py Anpassungen und Ergänzungen gemacht.