### PR TITLE
changing colors and name at buttons

### DIFF
--- a/webapp/orders/templates/create_order.html
+++ b/webapp/orders/templates/create_order.html
@@ -20,7 +20,7 @@
             <td class="col-fixed-100">
                 {{ form.request_date(class="form-control", type="hidden") }}
                 <span id="selected_date_display">Kein Datum ausgewählt</span>
-                <button type="button" class="btn btn-sm btn-outline-secondary"
+                <button type="button" class="btn btn-sm btn-primary"
                         hx-get="{{ url_for('orders.show_calendar', picker=True, target_id=form.request_date.id, display_id='selected_date_display') }}"
                         hx-target="#calendar-container-modal .modal-body"
                         hx-swap="innerHTML"
@@ -58,7 +58,7 @@
 
 <br>
 <br>
-  <button type="submit" class="btn" name="action" value="save_order" style="background-color: #a020f0; color: white;"
+  <button type="submit" class="btn btn-success" name="action" value="save_order"
           onclick="return confirm('Hast Du ein Datum ausgewählt?');">
    Weiter
   </button>
@@ -70,7 +70,7 @@
   </button>
 
 
-<a class="btn btn-warning" style="background-color: #007bff; color: white;" href="{{ url_for('main.home') }}" >Zur Startseite</a>
+<a class="btn btn-warning" style="background-color: #007bff; color: white;" href="{{ url_for('main.home') }}" >abbrechen</a>
 {% endif %}
 </form>
 

--- a/webapp/orders/templates/edit_order_pos.html
+++ b/webapp/orders/templates/edit_order_pos.html
@@ -119,7 +119,7 @@ function unused() {
             {{ form.head.request_date.data.strftime('%Y-%m-%d') if form.head.request_date.data else 'Kein Datum ausgewählt' }}
           </span>
           <button type="button"
-                  class="btn btn-sm btn-outline-secondary"
+                  class="btn btn-sm btn-primary"
                   hx-get="{{ url_for('orders.show_calendar', year=form.head.request_date.data.year, month=form.head.request_date.data.month, picker=True, target_id=form.head.request_date.id, display_id='selected_date_display') }}"
                   hx-target="#calendar-container-modal .modal-body"
                   hx-swap="innerHTML"
@@ -327,7 +327,7 @@ function unused() {
     Objekt Koordinaten ergänzen
   </button>
 
-  <a class="btn btn-primary" href="{{ url_for('main.home') }}">Zur Startseite</a>
+  <a class="btn btn-primary" href="{{ url_for('main.home') }}">Abbrechen</a>
 
   <div id="flatten-hidden" style="display:none;"></div>
   {% endif %}


### PR DESCRIPTION
i. V. m. Issue #177  👍 

a) Farben der Buttons inkonsistent, "Weiter" sollte gleiche Farbe wie "Sichern" haben

erledigt


b) "Kalender anzeigen" am besten entfernen, 

Dieser Button ist bereits als Kommentar und aktuell nicht aktiv


c) "Zur Startseite" besser "Abbruch", da das Formular dann weg ist.

erledigt


Zusätzlich ist nachdem Testtreffen am 15. August die angesprochene Änderung des Kalenderbuttons deutlicher darstellen nun der Kalender Button in blau. Der Button ist so im Dark und Lightmode erkennbar.