### PR TITLE
231 reject page table incomplete

### DIFF
--- a/webapp/orders/routes.py
+++ b/webapp/orders/routes.py
@@ -708,6 +708,9 @@ def reject_order(order_id):
     user=User.query.get(order_head.user_id)
     observatory = Observatory.query.get(order_head.request_observatory_id)
     reservation = ObservatoryReservation.query.filter_by(observation_request_id=order_id).first()
+    positions = ObservationRequestPosition.query.filter_by(
+    observation_request_id=order_id
+).all()
     order_head.status_label = ORDER_STATUS_LABELS.get(order_head.status, "??")
     form = RejectOrderForm()
     if form.validate_on_submit():
@@ -737,7 +740,7 @@ def reject_order(order_id):
         # formular befuellen (hier nichts?)
         pass
     return render_template('reject_order.html',
-                           form=form, order=order_head, user=user, observatory=observatory, reservation=reservation)
+                           form=form, order=order_head, user=user, observatory=observatory, reservation=reservation, order_position=positions)
 
 
 # --------------------------------------------------------------------

--- a/webapp/orders/templates/reject_order.html
+++ b/webapp/orders/templates/reject_order.html
@@ -29,7 +29,8 @@
             <th>Fokussieren</th>
         </tr>
     </thead>
-    {% for order_pos in order_position %}
+    <tbody>
+    {% for order_pos in order_position %}    
         <tr>
             <td>{{order_pos.telescope.name}}</td>
             <td>{{order_pos.filterset.name}}</td>
@@ -47,7 +48,7 @@
             <td>{{order_pos.exposure_focus}}</td>
         </tr>
     {% endfor %}
-    <tbody>
+    </tbody>
 </table>
 <br/>
 


### PR DESCRIPTION
Vergleichbar bei show_order_positions ist bei diesem Issue in reject_order() die Datenbankübermittlung positions = ObservationRequestPosition.query.filter_by(
    observation_request_id=order_id
).all() nicht enthalten gewesen. Dies ist jetzt ergänzt

Dieser PR steht i. V. m. Issue #231 
